### PR TITLE
Simplify and fix rule tutorial logging

### DIFF
--- a/rules/CMakeLists.txt
+++ b/rules/CMakeLists.txt
@@ -17,8 +17,10 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-# Use a custom gaia config file to suppress rule stats logging.
+# Use custom gaia config files to suppress rule stats logging and use an abbreviated
+# format string for tutorial output.
 configure_file("${PROJECT_SOURCE_DIR}/gaia.conf" "${PROJECT_BINARY_DIR}/gaia_tutorial.conf")
+configure_file("${PROJECT_SOURCE_DIR}/gaia_log.conf" "${PROJECT_BINARY_DIR}/gaia_tutorial_log.conf")
 
 include("/opt/gaia/cmake/gaia.cmake")
 

--- a/rules/clinic.cpp
+++ b/rules/clinic.cpp
@@ -274,7 +274,7 @@ int main(int argc, const char** argv)
 
     // Load up a custom configuration file so that we don't
     // log rule statistics during the tutorial.
-    gaia::system::initialize("./gaia_tutorial.conf");
+    gaia::system::initialize("./gaia_tutorial.conf", "./gaia_tutorial_log.conf");
 
     args_handler_t args_handler(lesson_manager);
     args_handler.parse_and_run(argc, argv);

--- a/rules/clinic.ruleset
+++ b/rules/clinic.ruleset
@@ -837,9 +837,9 @@ ruleset interop
         }
     }
 
-    // [interop:6_location]
+    // [interop:6_resident]
     //
-    // Show how to read and write a null to an optional field.
+    // Show how to read an optional field and set to 'nullopt'.
     on_update(resident.is_intern)
     {
         if (!is_intern)
@@ -862,9 +862,9 @@ ruleset interop
         }
     }
 
-    // [interop:7_location]
+    // [interop:7_resident]
     //
-    // Show how to read and write optional fields.
+    // Show how to set an optional field.
     on_update(resident.is_intern)
     {
         if (is_intern)

--- a/rules/gaia_log.conf
+++ b/rules/gaia_log.conf
@@ -1,0 +1,92 @@
+global_pattern = "%v"
+
+# Sinks
+
+[[sink]]
+name = "console"
+type = "stderr_sink_mt"
+
+[[sink]]
+name = "file_rotating"
+type = "rotating_file_sink_mt"
+base_filename = "logs/gaia.log"
+max_size = "1M"
+max_files = 10
+create_parent_dir = true
+
+# Simplify the log string pattern for the statistics logger.  Only include a timestamp,
+# process id, and logger name for the prefix.
+[[pattern]]
+name = "stats"
+value = "[%Y-%m-%dT%T] [%P] <%n>: %v"
+
+# Log statistics in a separate file from our other logging.
+[[sink]]
+name = "stats_rotating"
+type = "rotating_file_sink_mt"
+base_filename = "logs/gaia_stats.log"
+max_size = "1M"
+max_files = 10
+create_parent_dir = true
+
+# syslog currently disabled: https://gaiaplatform.atlassian.net/browse/GAIAPLAT-387
+#[[sink]]
+#name = "syslog"
+#type = "syslog_sink_mt"
+# Generally no need to fill in the optional fields below.
+# ident = "" (default)
+# syslog_option = 0 (default)
+# syslog_facility = LOG_USER (default macro value)
+
+# Public loggers
+
+[[logger]]
+name = "app"
+sinks = [
+    "console",
+    "file_rotating"
+]
+level = "info"
+
+# Internal Loggers
+
+[[logger]]
+name = "sys"
+sinks = [
+    "console",
+    "file_rotating"
+]
+level = "info"
+
+[[logger]]
+name = "db"
+sinks = [
+    "console",
+    "file_rotating"
+]
+level = "info"
+
+[[logger]]
+name = "catalog"
+sinks = [
+    "console",
+    "file_rotating"
+]
+level = "info"
+
+[[logger]]
+name = "rules"
+sinks = [
+    "console",
+    "file_rotating"
+]
+level = "info"
+
+# The statistics logger only writes to a file sink.
+[[logger]]
+name = "rules_stats"
+sinks = [
+    "stats_rotating"
+]
+pattern = "stats"
+level = "info"


### PR DESCRIPTION
Simplify tutorial logging:
```
dax@ade:~/rules/build$ ./rules
---------------------------
--- [Lesson: 01_basics] ---
---------------------------
db: inserting a physician in the database
basics:1_physician: physician 'Dr. House' was inserted.
Press <enter> to continue...

db: inserting a resident in the database
basics:6_resident: resident 'Emma' was changed due to a 'row_insert' event on type '3181751070'.
Press <enter> to continue...
```

Also cleaned up a few typos in the optional rules.